### PR TITLE
Add __isset magic method

### DIFF
--- a/Infusionsoft/Generated/Base.php
+++ b/Infusionsoft/Generated/Base.php
@@ -102,6 +102,11 @@ class Infusionsoft_Generated_Base
         }
     }
 
+    public function __isset($property)
+    {
+        return (isset($this->$property) || $this->isValidField($property));
+    }
+
     public function isEmpty()
     {
         foreach($this->getFields() as $fieldName){


### PR DESCRIPTION
empty($contact->CompanyID) is always true even if $contact->CompanyID has a value. To fix this, I've added the __isset() magic method. It checks if the property exists as a normal property, or if it is a valid field. This allows empty() and isset() to work as expected.