### PR TITLE
Fixes property name for error description.

### DIFF
--- a/Infusionsoft/OAuth2.php
+++ b/Infusionsoft/OAuth2.php
@@ -122,7 +122,7 @@ class Infusionsoft_OAuth2 {
         $decodedResponse = json_decode($response, true);
 
         if(isset($decodedResponse['error'])){
-            throw new Exception($decodedResponse['error_description']);
+            throw new Exception($decodedResponse['error']);
         }
 
         return $decodedResponse;


### PR DESCRIPTION
Thanks for this library. 

I have noticed an occasional exception from Oauth2.php, but with no description of the error. After doing some digging, I determined that the property name containing the OAuth2 error message had changed from 'error_description' to simply 'error'. 

If this is not universal for all OAuth2 errors, we could add in some type checking, or pass in the encoded JSON response as the message - a little sloppy, but hedges against the service changing things around in the future.