### PR TITLE
resolve PHP 7.2 warning related to count() in xmlrpc.inc

### DIFF
--- a/Infusionsoft/xmlrpc.inc
+++ b/Infusionsoft/xmlrpc.inc
@@ -2659,7 +2659,7 @@ class xmlrpcmsg
 
 
         // first error check: xml not well formed
-        if(!xml_parse($parser, $data, count($data)))
+        if(!xml_parse($parser, $data, strlen($data)))
         {
             try{
                 $bad_return = fopen("bad_return.xml.php", "w");


### PR DESCRIPTION
PHP 7.2 requires the parameter passed to count() to be an array or countable. 

http://php.net/manual/en/migration72.incompatible.php

xmlrpc.inc uses count() on a string on line 2662, which throws a warning with every XMLRPC call - a simple change to strlen() fixes the issue.
